### PR TITLE
Add domain exclusion filter functionality to HAR processing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,7 @@ async function main(): Promise<void> {
           statusCode: options.statusCode,
           method: options.method,
           urlPattern: options.urlPattern,
+          excludeDomains: options.excludeDomains,
         },
       });
     }

--- a/src/handlers/har-viewer-handler.test.ts
+++ b/src/handlers/har-viewer-handler.test.ts
@@ -33,6 +33,30 @@ describe('handleHarViewer', () => {
     });
   });
 
+  it('should handle excludeDomains filter parameter', async () => {
+    const mockFormattedHar = '[1] 200 GET https://example.com';
+    const mockArgs = {
+      filePath: '/path/to/example.har',
+      showQueryParams: false,
+      filter: {
+        excludeDomains: ['google.com', 'analytics.com'],
+      },
+    };
+
+    vi.mocked(harParser.parseAndFormatHar).mockResolvedValue(mockFormattedHar);
+
+    const result = await handleHarViewer(mockArgs);
+
+    expect(harParser.parseAndFormatHar).toHaveBeenCalledWith(mockArgs.filePath, {
+      showQueryParams: mockArgs.showQueryParams,
+      filter: mockArgs.filter,
+    });
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: mockFormattedHar }],
+    });
+  });
+
   it('should handle errors during HAR parsing', async () => {
     const mockError = new Error('Failed to read HAR file');
     const mockArgs = {

--- a/src/handlers/har-viewer-handler.ts
+++ b/src/handlers/har-viewer-handler.ts
@@ -19,6 +19,10 @@ export const harViewerSchema = z.object({
         .string()
         .optional()
         .describe('Filter requests by URL pattern (substring match)'),
+      excludeDomains: z
+        .array(z.string())
+        .optional()
+        .describe('Domains to exclude from the output (multiple domains can be specified)'),
     })
     .optional()
     .describe('Optional filters to narrow down the displayed requests'),

--- a/src/types/har.ts
+++ b/src/types/har.ts
@@ -51,6 +51,7 @@ export interface HarFilter {
   statusCode?: number;
   method?: string;
   urlPattern?: string;
+  excludeDomains?: string[];
 }
 
 /**

--- a/src/utils/cli-parser.test.ts
+++ b/src/utils/cli-parser.test.ts
@@ -60,6 +60,22 @@ describe('CLI parser', () => {
     expect(options?.urlPattern).toBe('api');
   });
 
+  it('should parse exclude-domains option', () => {
+    const args = ['list', 'example.har', '--exclude-domains', 'example.com,analytics.com'];
+    const options = parseCliArgs(args);
+
+    expect(options).not.toBeNull();
+    expect(options?.excludeDomains).toEqual(['example.com', 'analytics.com']);
+  });
+
+  it('should parse exclude-domains shorthand option', () => {
+    const args = ['list', 'example.har', '-e', 'example.com'];
+    const options = parseCliArgs(args);
+
+    expect(options).not.toBeNull();
+    expect(options?.excludeDomains).toEqual(['example.com']);
+  });
+
   it('should return null for help request', () => {
     const args = ['--help'];
     const options = parseCliArgs(args);

--- a/src/utils/cli-parser.ts
+++ b/src/utils/cli-parser.ts
@@ -12,6 +12,7 @@ export interface CliOptions {
   statusCode?: number;
   method?: string;
   urlPattern?: string;
+  excludeDomains?: string[];
   // Detail mode options
   hashes?: string;
   showBody: boolean;
@@ -48,6 +49,7 @@ export function parseCliArgs(args: string[]): CliOptions | null {
       status: { type: 'string', short: 's' },
       method: { type: 'string', short: 'm' },
       url: { type: 'string', short: 'u' },
+      'exclude-domains': { type: 'string', short: 'e' },
       hashes: { type: 'string', short: 'h' },
       body: { type: 'boolean', short: 'b', default: false },
     },
@@ -74,6 +76,11 @@ export function parseCliArgs(args: string[]): CliOptions | null {
     }
   }
 
+  // Process exclude-domains if provided (convert comma-separated list to array)
+  const excludeDomains = values['exclude-domains']
+    ? values['exclude-domains'].split(',').map((domain) => domain.trim())
+    : undefined;
+
   return {
     filePath,
     command,
@@ -81,6 +88,7 @@ export function parseCliArgs(args: string[]): CliOptions | null {
     statusCode,
     method: values.method,
     urlPattern: values.url,
+    excludeDomains,
     hashes: values.hashes,
     showBody: values.body || false,
   };
@@ -109,6 +117,7 @@ List Command Options:
   -s, --status <code>    Filter by status code
   -m, --method <method>  Filter by HTTP method
   -u, --url <pattern>    Filter by URL pattern
+  -e, --exclude-domains <domains> Exclude requests from specified domains (comma-separated)
 
 Detail Command Options:
   -h, --hashes <list>    Comma-separated list of hash identifiers to show

--- a/src/utils/har-formatter.test.ts
+++ b/src/utils/har-formatter.test.ts
@@ -147,6 +147,25 @@ describe('HAR Formatter', () => {
       );
       expect(result).toMatch(/\[[0-9a-f]{7}\] 201 PUT https:\/\/api\.example\.com\/update/);
     });
+
+    it('should filter entries by excluded domains', () => {
+      const result = formatHarEntries(mockHarData, {
+        showQueryParams: true,
+        filter: { excludeDomains: ['api.example.com'] },
+      });
+      // Should only include example.com but not api.example.com
+      expect(result).toMatch(/\[[0-9a-f]{7}\] 200 GET https:\/\/example\.com\/api\?param=value/);
+      expect(result).not.toMatch(/api\.example\.com/);
+    });
+
+    it('should filter entries by excluded parent domains', () => {
+      const result = formatHarEntries(mockHarData, {
+        showQueryParams: true,
+        filter: { excludeDomains: ['example.com'] },
+      });
+      // Should exclude both example.com and api.example.com
+      expect(result).toBe('');
+    });
   });
 
   describe('formatHeaders', () => {

--- a/src/utils/har-formatter.ts
+++ b/src/utils/har-formatter.ts
@@ -49,6 +49,21 @@ export function formatHarEntries(harData: HarFile, options: FormatOptions): stri
         (entry) => filter.urlPattern !== undefined && entry.request.url.includes(filter.urlPattern)
       );
     }
+
+    if (filter.excludeDomains !== undefined && filter.excludeDomains.length > 0) {
+      filteredEntries = filteredEntries.filter((entry) => {
+        try {
+          const url = new URL(entry.request.url);
+          const hostname = url.hostname;
+          return !filter.excludeDomains?.some(
+            (domain) => hostname === domain || hostname.endsWith(`.${domain}`)
+          );
+        } catch {
+          // If URL parsing fails, keep the entry
+          return true;
+        }
+      });
+    }
   }
 
   // Process each entry


### PR DESCRIPTION
This PR implements a new feature to exclude specified domains from HAR output, allowing users to filter out noise from analytics, tracking, or other irrelevant domains.

Changes include:
- Added `excludeDomains` filter option in CLI arguments with shorthand `-e`
- Updated HAR viewer handler to support domain exclusion filtering
- Enhanced HAR formatter to filter out entries from excluded domains
- Added comprehensive tests for the new functionality